### PR TITLE
FOR-Namespace hinzugefügt

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,6 +1,11 @@
 <?php
+
+use FriendsOfRedaxo\RelationSelect\RelationSelect;
+
 if (rex::isBackend() && rex_be_controller::getCurrentPage() != 'login') {
     rex_view::addJsFile('https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js');
     rex_view::addJsFile(rex_url::addonAssets('relation_select', 'relation_select.js'));
     rex_view::addCssFile(rex_url::addonAssets('relation_select', 'relation_select.css'));
 }
+
+rex_api_function::register('relation_select', RelationSelect::class);

--- a/lib/api.php
+++ b/lib/api.php
@@ -1,5 +1,13 @@
 <?php
-class rex_api_relation_select extends rex_api_function
+
+namespace FriendsOfRedaxo\RelationSelect;
+
+use rex_api_exception;
+use rex_api_function;
+use rex_sql;
+use rex_sql_exception;
+
+class RelationSelect extends rex_api_function
 {
     protected $published = true;
 

--- a/package.yml
+++ b/package.yml
@@ -4,6 +4,6 @@ author: Your Name
 supportpage: https://github.com/your/repo
 
 requires:
-    redaxo: '^5.13'
+    redaxo: '^5.17'
     php:
-        version: '>=8.0'
+        version: '>=8.1'


### PR DESCRIPTION
Für APIs gibt es mittlerweile (ab Redaxo 5.17) die Möglichkeit, die Klasse in den Namespace zu packen und auf einen API-Namen zu registrieren.

Von daher mein Vorschlag, dem Addon auch einen Namespace zu verpassen. Dann hat man es hinter sich ,solange das Addon noch eine DEV-Version ist.

Allerdings müssen dann auch in der package.yml Voraussetzungen angepasst werden. 
Redaxo-Mndestversin 5.17 (released März 2024) und PHP auf mindestens 8.1.